### PR TITLE
Allow 0 for Persistent Keep Alive

### DIFF
--- a/wireguard-server.sh
+++ b/wireguard-server.sh
@@ -403,7 +403,7 @@ if [ ! -f "$WG_CONFIG" ]; then
       NAT_CHOICE="25"
       ;;
     2)
-      until [[ "$NAT_CHOICE" =~ ^[0-9]+$ ]] && [ "$NAT_CHOICE" -ge 1 ] && [ "$NAT_CHOICE" -le 25 ]; do
+      until [[ "$NAT_CHOICE" =~ ^[0-9]+$ ]] && [ "$NAT_CHOICE" -ge 0 ] && [ "$NAT_CHOICE" -le 25 ]; do
         read -rp "Custom NAT [0-25]: " -e -i 25 NAT_CHOICE
       done
       ;;


### PR DESCRIPTION
Small bug when picking the NAT keep alive time. Should allow 0, which is the wiregarud default. 