### PR TITLE
Update wireguard-server.sh

### DIFF
--- a/wireguard-server.sh
+++ b/wireguard-server.sh
@@ -633,7 +633,7 @@ if [ ! -f "$WG_CONFIG" ]; then
     if [ "$DISTRO" == "arch" ]; then
       pacman -Syu
       pacman -Syu --noconfirm haveged qrencode iptables
-      pacman -Syu --noconfirm wireguard-tools wireguard
+      pacman -Syu --noconfirm wireguard-tools
     fi
     if [ "$DISTRO" = "fedora" ] && [ "$DISTRO_VERSION" == "32" ]; then
       dnf update -y


### PR DESCRIPTION
again fix arch package name in pacman - "wireguard-tools" exists only in arch repo.