### PR TITLE
Add support for archarm (and other arch ports)

### DIFF
--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -27,13 +27,13 @@ dist-check
 
 # Pre-Checks system requirements
 function installing-system-requirements() {
-  if { [ "$DISTRO" == "ubuntu" ] || [ "$DISTRO" == "debian" ] || [ "$DISTRO" == "raspbian" ] || [ "$DISTRO" == "pop" ] || [ "$DISTRO" == "kali" ] || [ "$DISTRO" == "linuxmint" ] || [ "$DISTRO" == "fedora" ] || [ "$DISTRO" == "centos" ] || [ "$DISTRO" == "rhel" ] || [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ] || [ "$DISTRO" == "alpine" ] || [ "$DISTRO" == "freebsd" ]; }; then
+  if { [ "$DISTRO" == "ubuntu" ] || [ "$DISTRO" == "debian" ] || [ "$DISTRO" == "raspbian" ] || [ "$DISTRO" == "pop" ] || [ "$DISTRO" == "kali" ] || [ "$DISTRO" == "linuxmint" ] || [ "$DISTRO" == "fedora" ] || [ "$DISTRO" == "centos" ] || [ "$DISTRO" == "rhel" ] || [[ "$DISTRO" == arch* ]] || [ "$DISTRO" == "manjaro" ] || [ "$DISTRO" == "alpine" ] || [ "$DISTRO" == "freebsd" ]; }; then
     if { [ ! -x "$(command -v curl)" ] || [ ! -x "$(command -v iptables)" ] || [ ! -x "$(command -v bc)" ] || [ ! -x "$(command -v jq)" ] || [ ! -x "$(command -v sed)" ] || [ ! -x "$(command -v zip)" ] || [ ! -x "$(command -v unzip)" ] || [ ! -x "$(command -v grep)" ] || [ ! -x "$(command -v awk)" ] || [ ! -x "$(command -v shuf)" ] || [ ! -x "$(command -v openssl)" ]; }; then
       if { [ "$DISTRO" == "ubuntu" ] || [ "$DISTRO" == "debian" ] || [ "$DISTRO" == "raspbian" ] || [ "$DISTRO" == "pop" ] || [ "$DISTRO" == "kali" ] || [ "$DISTRO" == "linuxmint" ]; }; then
         apt-get update && apt-get install iptables curl coreutils bc jq sed e2fsprogs zip unzip grep gawk iproute2 systemd openssl -y
       elif { [ "$DISTRO" == "fedora" ] || [ "$DISTRO" == "centos" ] || [ "$DISTRO" == "rhel" ]; }; then
         yum update -y && yum install iptables curl coreutils bc jq sed e2fsprogs zip unzip grep gawk systemd openssl -y
-      elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
+      elif { [[ "$DISTRO" == arch* ]] || [ "$DISTRO" == "manjaro" ]; }; then
         pacman -Syu --noconfirm --needed iptables curl bc jq sed zip unzip grep gawk iproute2 systemd coreutils openssl
       elif [ "$DISTRO" == "alpine" ]; then
         apk update && apk add iptables curl bc jq sed zip unzip grep gawk iproute2 systemd coreutils openssl
@@ -715,7 +715,7 @@ if [ ! -f "$WIREGUARD_CONFIG" ]; then
         elif [ "$DISTRO" == "raspbian" ]; then
           apt-get update
           apt-get install raspberrypi-kernel-headers -y
-        elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
+        elif { [[ "$DISTRO" == arch* ]] || [ "$DISTRO" == "manjaro" ]; }; then
           pacman -Syu
           pacman -Syu --noconfirm linux-headers
         elif [ "$DISTRO" == "fedora" ]; then
@@ -772,7 +772,7 @@ if [ ! -f "$WIREGUARD_CONFIG" ]; then
           fi
           apt-get update
           apt-get install wireguard qrencode haveged ifupdown resolvconf -y
-        elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
+        elif { [[ "$DISTRO" == arch* ]] || [ "$DISTRO" == "manjaro" ]; }; then
           pacman -Syu
           pacman -Syu --noconfirm --needed haveged qrencode iptables resolvconf
           pacman -Syu --noconfirm wireguard-tools
@@ -854,7 +854,7 @@ if [ ! -f "$WIREGUARD_CONFIG" ]; then
             yum install unbound unbound-libs -y
           elif [ "$DISTRO" == "fedora" ]; then
             dnf install unbound -y
-          elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
+          elif { [[ "$DISTRO" == arch* ]] || [ "$DISTRO" == "manjaro" ]; }; then
             pacman -Syu --noconfirm unbound
           elif [ "$DISTRO" == "alpine" ]; then
             apk add unbound
@@ -1210,7 +1210,7 @@ PublicKey = $SERVER_PUBKEY" >>$WIREGUARD_CLIENT_PATH/"$NEW_CLIENT_NAME"-$WIREGUA
         elif { [ "$DISTRO" == "fedora" ] || [ "$DISTRO" == "centos" ] || [ "$DISTRO" == "rhel" ]; }; then
           yum reinstall wireguard-tools -y
           service wg-quick@$WIREGUARD_PUB_NIC restart
-        elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
+        elif { [[ "$DISTRO" == arch* ]] || [ "$DISTRO" == "manjaro" ]; }; then
           pacman -Rs --noconfirm wireguard-tools
           service wg-quick@$WIREGUARD_PUB_NIC restart
         elif [ "$DISTRO" == "alpine" ]; then
@@ -1256,7 +1256,7 @@ PublicKey = $SERVER_PUBKEY" >>$WIREGUARD_CLIENT_PATH/"$NEW_CLIENT_NAME"-$WIREGUA
               apt-get remove --purge wireguard qrencode haveged dirmngr -y
               rm -f /etc/apt/sources.list.d/unstable.list
               rm -f /etc/apt/preferences.d/limit-unstable
-            elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
+            elif { [[ "$DISTRO" == arch* ]] || [ "$DISTRO" == "manjaro" ]; }; then
               pacman -Rs wireguard qrencode haveged -y
             elif [ "$DISTRO" == "fedora" ]; then
               dnf remove wireguard qrencode haveged -y
@@ -1291,7 +1291,7 @@ PublicKey = $SERVER_PUBKEY" >>$WIREGUARD_CLIENT_PATH/"$NEW_CLIENT_NAME"-$WIREGUA
               yum remove unbound unbound-host -y
             elif { [ "$DISTRO" == "debian" ] || [ "$DISTRO" == "pop" ] || [ "$DISTRO" == "ubuntu" ] || [ "$DISTRO" == "raspbian" ] || [ "$DISTRO" == "kali" ] || [ "$DISTRO" == "linuxmint" ]; }; then
               apt-get remove --purge unbound unbound-host -y
-            elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
+            elif { [[ "$DISTRO" == arch* ]] || [ "$DISTRO" == "manjaro" ]; }; then
               pacman -Rs unbound unbound-host -y
             elif [ "$DISTRO" == "fedora" ]; then
               dnf remove unbound -y
@@ -1442,7 +1442,7 @@ PublicKey = $SERVER_PUBKEY" >>$WIREGUARD_CLIENT_PATH/"$NEW_CLIENT_NAME"-$WIREGUA
         elif { [ "$DISTRO" == "fedora" ] || [ "$DISTRO" == "centos" ] || [ "$DISTRO" == "rhel" ]; }; then
           yum reinstall wireguard-dkms -y
           service wg-quick@$WIREGUARD_PUB_NIC restart
-        elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
+        elif { [[ "$DISTRO" == arch* ]] || [ "$DISTRO" == "manjaro" ]; }; then
           pacman -Rs --noconfirm wireguard-tools
           service wg-quick@$WIREGUARD_PUB_NIC restart
         elif [ "$DISTRO" == "alpine" ]; then
@@ -1488,7 +1488,7 @@ PublicKey = $SERVER_PUBKEY" >>$WIREGUARD_CLIENT_PATH/"$NEW_CLIENT_NAME"-$WIREGUA
               apt-get remove --purge wireguard qrencode haveged dirmngr -y
               rm -f /etc/apt/sources.list.d/unstable.list
               rm -f /etc/apt/preferences.d/limit-unstable
-            elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
+            elif { [[ "$DISTRO" == arch* ]] || [ "$DISTRO" == "manjaro" ]; }; then
               pacman -Rs wireguard qrencode haveged -y
             elif [ "$DISTRO" == "fedora" ]; then
               dnf remove wireguard qrencode haveged -y

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -27,13 +27,13 @@ dist-check
 
 # Pre-Checks system requirements
 function installing-system-requirements() {
-  if { [ "$DISTRO" == "ubuntu" ] || [ "$DISTRO" == "debian" ] || [ "$DISTRO" == "raspbian" ] || [ "$DISTRO" == "pop" ] || [ "$DISTRO" == "kali" ] || [ "$DISTRO" == "linuxmint" ] || [ "$DISTRO" == "fedora" ] || [ "$DISTRO" == "centos" ] || [ "$DISTRO" == "rhel" ] || [ "$DISTRO" == "arch" ] || [ "$DISTRO" == "manjaro" ] || [ "$DISTRO" == "alpine" ] || [ "$DISTRO" == "freebsd" ]; }; then
+  if { [ "$DISTRO" == "ubuntu" ] || [ "$DISTRO" == "debian" ] || [ "$DISTRO" == "raspbian" ] || [ "$DISTRO" == "pop" ] || [ "$DISTRO" == "kali" ] || [ "$DISTRO" == "linuxmint" ] || [ "$DISTRO" == "fedora" ] || [ "$DISTRO" == "centos" ] || [ "$DISTRO" == "rhel" ] || [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ] || [ "$DISTRO" == "alpine" ] || [ "$DISTRO" == "freebsd" ]; }; then
     if { [ ! -x "$(command -v curl)" ] || [ ! -x "$(command -v iptables)" ] || [ ! -x "$(command -v bc)" ] || [ ! -x "$(command -v jq)" ] || [ ! -x "$(command -v sed)" ] || [ ! -x "$(command -v zip)" ] || [ ! -x "$(command -v unzip)" ] || [ ! -x "$(command -v grep)" ] || [ ! -x "$(command -v awk)" ] || [ ! -x "$(command -v shuf)" ] || [ ! -x "$(command -v openssl)" ]; }; then
       if { [ "$DISTRO" == "ubuntu" ] || [ "$DISTRO" == "debian" ] || [ "$DISTRO" == "raspbian" ] || [ "$DISTRO" == "pop" ] || [ "$DISTRO" == "kali" ] || [ "$DISTRO" == "linuxmint" ]; }; then
         apt-get update && apt-get install iptables curl coreutils bc jq sed e2fsprogs zip unzip grep gawk iproute2 systemd openssl -y
       elif { [ "$DISTRO" == "fedora" ] || [ "$DISTRO" == "centos" ] || [ "$DISTRO" == "rhel" ]; }; then
         yum update -y && yum install iptables curl coreutils bc jq sed e2fsprogs zip unzip grep gawk systemd openssl -y
-      elif { [ "$DISTRO" == "arch" ] || [ "$DISTRO" == "manjaro" ]; }; then
+      elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
         pacman -Syu --noconfirm --needed iptables curl bc jq sed zip unzip grep gawk iproute2 systemd coreutils openssl
       elif [ "$DISTRO" == "alpine" ]; then
         apk update && apk add iptables curl bc jq sed zip unzip grep gawk iproute2 systemd coreutils openssl
@@ -715,7 +715,7 @@ if [ ! -f "$WIREGUARD_CONFIG" ]; then
         elif [ "$DISTRO" == "raspbian" ]; then
           apt-get update
           apt-get install raspberrypi-kernel-headers -y
-        elif { [ "$DISTRO" == "arch" ] || [ "$DISTRO" == "manjaro" ]; }; then
+        elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
           pacman -Syu
           pacman -Syu --noconfirm linux-headers
         elif [ "$DISTRO" == "fedora" ]; then
@@ -772,7 +772,7 @@ if [ ! -f "$WIREGUARD_CONFIG" ]; then
           fi
           apt-get update
           apt-get install wireguard qrencode haveged ifupdown resolvconf -y
-        elif { [ "$DISTRO" == "arch" ] || [ "$DISTRO" == "manjaro" ]; }; then
+        elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
           pacman -Syu
           pacman -Syu --noconfirm --needed haveged qrencode iptables resolvconf
           pacman -Syu --noconfirm wireguard-tools
@@ -854,7 +854,7 @@ if [ ! -f "$WIREGUARD_CONFIG" ]; then
             yum install unbound unbound-libs -y
           elif [ "$DISTRO" == "fedora" ]; then
             dnf install unbound -y
-          elif { [ "$DISTRO" == "arch" ] || [ "$DISTRO" == "manjaro" ]; }; then
+          elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
             pacman -Syu --noconfirm unbound
           elif [ "$DISTRO" == "alpine" ]; then
             apk add unbound
@@ -1210,7 +1210,7 @@ PublicKey = $SERVER_PUBKEY" >>$WIREGUARD_CLIENT_PATH/"$NEW_CLIENT_NAME"-$WIREGUA
         elif { [ "$DISTRO" == "fedora" ] || [ "$DISTRO" == "centos" ] || [ "$DISTRO" == "rhel" ]; }; then
           yum reinstall wireguard-tools -y
           service wg-quick@$WIREGUARD_PUB_NIC restart
-        elif { [ "$DISTRO" == "arch" ] || [ "$DISTRO" == "manjaro" ]; }; then
+        elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
           pacman -Rs --noconfirm wireguard-tools
           service wg-quick@$WIREGUARD_PUB_NIC restart
         elif [ "$DISTRO" == "alpine" ]; then
@@ -1256,7 +1256,7 @@ PublicKey = $SERVER_PUBKEY" >>$WIREGUARD_CLIENT_PATH/"$NEW_CLIENT_NAME"-$WIREGUA
               apt-get remove --purge wireguard qrencode haveged dirmngr -y
               rm -f /etc/apt/sources.list.d/unstable.list
               rm -f /etc/apt/preferences.d/limit-unstable
-            elif { [ "$DISTRO" == "arch" ] || [ "$DISTRO" == "manjaro" ]; }; then
+            elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
               pacman -Rs wireguard qrencode haveged -y
             elif [ "$DISTRO" == "fedora" ]; then
               dnf remove wireguard qrencode haveged -y
@@ -1291,7 +1291,7 @@ PublicKey = $SERVER_PUBKEY" >>$WIREGUARD_CLIENT_PATH/"$NEW_CLIENT_NAME"-$WIREGUA
               yum remove unbound unbound-host -y
             elif { [ "$DISTRO" == "debian" ] || [ "$DISTRO" == "pop" ] || [ "$DISTRO" == "ubuntu" ] || [ "$DISTRO" == "raspbian" ] || [ "$DISTRO" == "kali" ] || [ "$DISTRO" == "linuxmint" ]; }; then
               apt-get remove --purge unbound unbound-host -y
-            elif { [ "$DISTRO" == "arch" ] || [ "$DISTRO" == "manjaro" ]; }; then
+            elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
               pacman -Rs unbound unbound-host -y
             elif [ "$DISTRO" == "fedora" ]; then
               dnf remove unbound -y
@@ -1442,7 +1442,7 @@ PublicKey = $SERVER_PUBKEY" >>$WIREGUARD_CLIENT_PATH/"$NEW_CLIENT_NAME"-$WIREGUA
         elif { [ "$DISTRO" == "fedora" ] || [ "$DISTRO" == "centos" ] || [ "$DISTRO" == "rhel" ]; }; then
           yum reinstall wireguard-dkms -y
           service wg-quick@$WIREGUARD_PUB_NIC restart
-        elif { [ "$DISTRO" == "arch" ] || [ "$DISTRO" == "manjaro" ]; }; then
+        elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
           pacman -Rs --noconfirm wireguard-tools
           service wg-quick@$WIREGUARD_PUB_NIC restart
         elif [ "$DISTRO" == "alpine" ]; then
@@ -1488,7 +1488,7 @@ PublicKey = $SERVER_PUBKEY" >>$WIREGUARD_CLIENT_PATH/"$NEW_CLIENT_NAME"-$WIREGUA
               apt-get remove --purge wireguard qrencode haveged dirmngr -y
               rm -f /etc/apt/sources.list.d/unstable.list
               rm -f /etc/apt/preferences.d/limit-unstable
-            elif { [ "$DISTRO" == "arch" ] || [ "$DISTRO" == "manjaro" ]; }; then
+            elif { [ "$DISTRO" == arch* ] || [ "$DISTRO" == "manjaro" ]; }; then
               pacman -Rs wireguard qrencode haveged -y
             elif [ "$DISTRO" == "fedora" ]; then
               dnf remove wireguard qrencode haveged -y


### PR DESCRIPTION
I'm trying to use the script on Archlinux on a Raspberry pi (alarmpi), and got `Error: archarm not supported.`. The package names between arch and archarm are the same and the script appears to work fine if I bypass the check.

This PR matches `arch*` distros as being archlinux, so it works for both `arch` and `archarm`, and eventually other Archlinux ports.

Another solution would be to manually add `archarm` to the list of distros with pacman.

Tell me what you think is the better solution