### PR TITLE
Add and Remove Peers without restarting Wireguard Service

### DIFF
--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1275,7 +1275,7 @@ Endpoint = ${SERVER_HOST}${SERVER_PORT}
 PersistentKeepalive = ${NAT_CHOICE}
 PresharedKey = ${PRESHARED_KEY}
 PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${WIREGUARD_PUB_NIC}.conf
-
+	    qrencode -t ansiutf8 -l L <${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${WIREGUARD_PUB_NIC}.conf
             # Reread wireguard config file.  Command below doesn't interfere with existing sessions
 	    wg addconf ${WIREGUARD_PUB_NIC} <(wg-quick strip ${WIREGUARD_PUB_NIC})
 

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1275,7 +1275,11 @@ Endpoint = ${SERVER_HOST}${SERVER_PORT}
 PersistentKeepalive = ${NAT_CHOICE}
 PresharedKey = ${PRESHARED_KEY}
 PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${WIREGUARD_PUB_NIC}.conf
-            qrencode -t ansiutf8 -l L <${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${WIREGUARD_PUB_NIC}.conf
+
+            # Reread wireguard config file.  Command below doesn't interfere with existing sessions
+	    wg addconf ${WIREGUARD_PUB_NIC} <(wg-quick strip ${WIREGUARD_PUB_NIC})
+
+	    qrencode -t ansiutf8 -l L <${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${WIREGUARD_PUB_NIC}.conf
             echo "Client config --> ${WIREGUARD_CLIENT_PATH}/${NEW_CLIENT_NAME}-${WIREGUARD_PUB_NIC}.conf"
           fi
         fi
@@ -1289,18 +1293,22 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
             read -rp "Type in Client Name : " -e REMOVECLIENT
             read -rp "Are you sure you want to remove ${REMOVECLIENT} ? (y/n): " -n 1 -r
             if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+
+	      # Get the user's public key
+	      CLIENTKEY=$(sed -n "/\# ${REMOVECLIENT} start/,/\# ${REMOVECLIENT} end/p" ${WIREGUARD_CONFIG} | grep PublicKey |  awk ' { print $3 } ')
+	      # Drops the client's current session.
+    	      wg set ${WIREGUARD_PUB_NIC} peer ${CLIENTKEY} remove
+
               sed -i "/\# ${REMOVECLIENT} start/,/\# ${REMOVECLIENT} end/d" ${WIREGUARD_CONFIG}
               rm -f ${WIREGUARD_CLIENT_PATH}/"${REMOVECLIENT}"-${WIREGUARD_PUB_NIC}.conf
               echo "Client ${REMOVECLIENT} has been removed."
             elif [[ ${REPLY} =~ ^[Nn]$ ]]; then
               exit
             fi
-            # Restart WireGuard
-            if pgrep systemd-journal; then
-              systemctl restart wg-quick@${WIREGUARD_PUB_NIC}
-            else
-              service wg-quick@${WIREGUARD_PUB_NIC} restart
-            fi
+
+            # Reread wireguard config file.  Command below doesn't interfere with existing sessions
+	    wg addconf ${WIREGUARD_PUB_NIC} <(wg-quick strip ${WIREGUARD_PUB_NIC})
+
           fi
         fi
         ;;

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1275,7 +1275,7 @@ Endpoint = ${SERVER_HOST}${SERVER_PORT}
 PersistentKeepalive = ${NAT_CHOICE}
 PresharedKey = ${PRESHARED_KEY}
 PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${WIREGUARD_PUB_NIC}.conf
-	    qrencode -t ansiutf8 -l L <${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${WIREGUARD_PUB_NIC}.conf
+
             # Reread wireguard config file.  Command below doesn't interfere with existing sessions
 	    wg addconf ${WIREGUARD_PUB_NIC} <(wg-quick strip ${WIREGUARD_PUB_NIC})
 


### PR DESCRIPTION
The edits will add and remove a peer without disrupting the current Wireguard sessions of other users.

The edits preserve removing the user's configuration from the Wireguard configuration file.
