### PR TITLE
Fix script for Arch Linux and derivatives

### DIFF
--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1148,15 +1148,15 @@ PresharedKey = ${PRESHARED_KEY}
 PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${CLIENT_NAME}"-${WIREGUARD_PUB_NIC}.conf
       # Service Restart
       if pgrep systemd-journal; then
-        systemctl enable wg-quick@${WIREGUARD_PUB_NIC}
-        systemctl start wg-quick@${WIREGUARD_PUB_NIC}
-        systemctl enable ntp
-        systemctl start ntp
+        systemctl reenable wg-quick@${WIREGUARD_PUB_NIC}
+        systemctl restart wg-quick@${WIREGUARD_PUB_NIC}
+        systemctl reenable ntp
+        systemctl restart ntp
       else
         service wg-quick@${WIREGUARD_PUB_NIC} enable
-        service wg-quick@${WIREGUARD_PUB_NIC} start
+        service wg-quick@${WIREGUARD_PUB_NIC} restart
         service ntp enable
-        service ntp start
+        service ntp restart
       fi
       ntpq -p
       # Generate QR Code

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1379,7 +1379,7 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
                 rm -f /etc/apt/preferences.d/limit-unstable
               fi
             elif { [ "${DISTRO}" == "arch" ] || [ "${DISTRO}" == "archarm" ] || [ "${DISTRO}" == "manjaro" ]; }; then
-              pacman -Rs wireguard-tools qrencode haveged -y
+              pacman -Rs --noconfirm wireguard-tools qrencode haveged
             elif [ "${DISTRO}" == "fedora" ]; then
               dnf remove wireguard qrencode haveged -y
               if [ -f "/etc/yum.repos.d/wireguard.repo" ]; then
@@ -1418,7 +1418,7 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
             elif { [ "${DISTRO}" == "debian" ] || [ "${DISTRO}" == "pop" ] || [ "${DISTRO}" == "ubuntu" ] || [ "${DISTRO}" == "raspbian" ] || [ "${DISTRO}" == "kali" ] || [ "${DISTRO}" == "linuxmint" ]; }; then
               apt-get remove --purge unbound unbound-host -y
             elif { [ "${DISTRO}" == "arch" ] || [ "${DISTRO}" == "archarm" ] || [ "${DISTRO}" == "manjaro" ]; }; then
-              pacman -Rs unbound unbound-host -y
+              pacman -Rs --noconfirm unbound unbound-host
             elif [ "${DISTRO}" == "fedora" ]; then
               dnf remove unbound -y
             elif [ "${DISTRO}" == "alpine" ]; then

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1317,8 +1317,8 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
           yum reinstall wireguard-tools -y
           service wg-quick@${WIREGUARD_PUB_NIC} restart
         elif { [ "${DISTRO}" == "arch" ] || [ "${DISTRO}" == "archarm" ] || [ "${DISTRO}" == "manjaro" ]; }; then
-          pacman -Rs --noconfirm wireguard-tools
-          service wg-quick@${WIREGUARD_PUB_NIC} restart
+          pacman -S --noconfirm wireguard-tools
+          systemctl restart wg-quick@${WIREGUARD_PUB_NIC}
         elif [ "${DISTRO}" == "alpine" ]; then
           apk fix wireguard-tools
         elif [ "${DISTRO}" == "freebsd" ]; then

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1330,9 +1330,11 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
           if [ -x "$(command -v wg)" ]; then
             if pgrep systemd-journal; then
               systemctl disable wg-quick@${WIREGUARD_PUB_NIC}
+              systemctl stop wg-quick@${WIREGUARD_PUB_NIC}
               wg-quick down ${WIREGUARD_PUB_NIC}
             else
               service wg-quick@${WIREGUARD_PUB_NIC} disable
+              service wg-quick@${WIREGUARD_PUB_NIC} stop
               wg-quick down ${WIREGUARD_PUB_NIC}
             fi
             # Removing Wireguard Files

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -34,7 +34,7 @@ function installing-system-requirements() {
       elif { [ "${DISTRO}" == "fedora" ] || [ "${DISTRO}" == "centos" ] || [ "${DISTRO}" == "rhel" ]; }; then
         yum update -y && yum install iptables curl coreutils bc jq sed e2fsprogs zip unzip grep gawk systemd openssl cron ntp -y
       elif { [ "${DISTRO}" == "arch" ] || [ "${DISTRO}" == "archarm" ] || [ "${DISTRO}" == "manjaro" ]; }; then
-        pacman -Syu --noconfirm --needed iptables curl bc jq sed zip unzip grep gawk iproute2 systemd coreutils openssl cron ntp
+        pacman -Syu --noconfirm --needed bc jq zip unzip cronie ntp
       elif [ "${DISTRO}" == "alpine" ]; then
         apk update && apk add iptables curl bc jq sed zip unzip grep gawk iproute2 systemd coreutils openssl cron ntp
       elif [ "${DISTRO}" == "freebsd" ]; then
@@ -912,7 +912,7 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
           apt-get install wireguard qrencode haveged ifupdown resolvconf -y
         elif { [ "${DISTRO}" == "arch" ] || [ "${DISTRO}" == "archarm" ] || [ "${DISTRO}" == "manjaro" ]; }; then
           pacman -Syu
-          pacman -Syu --noconfirm --needed haveged qrencode iptables resolvconf
+          pacman -Syu --noconfirm --needed haveged qrencode openresolv
           pacman -Syu --noconfirm --needed wireguard-tools
         elif [ "${DISTRO}" = "fedora" ] && [ "${DISTRO_VERSION}" == "32" ]; then
           dnf update -y
@@ -1379,7 +1379,7 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
                 rm -f /etc/apt/preferences.d/limit-unstable
               fi
             elif { [ "${DISTRO}" == "arch" ] || [ "${DISTRO}" == "archarm" ] || [ "${DISTRO}" == "manjaro" ]; }; then
-              pacman -Rs wireguard qrencode haveged -y
+              pacman -Rs wireguard-tools qrencode haveged -y
             elif [ "${DISTRO}" == "fedora" ]; then
               dnf remove wireguard qrencode haveged -y
               if [ -f "/etc/yum.repos.d/wireguard.repo" ]; then

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -677,10 +677,10 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
         } | crontab -
         if pgrep systemd-journal; then
           systemctl enable cron
-          systemctl restart cron
+          systemctl start cron
         else
           service cron enable
-          service cron restart
+          service cron start
         fi
         ;;
       2)
@@ -729,10 +729,10 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
         } | crontab -
         if pgrep systemd-journal; then
           systemctl enable cron
-          systemctl restart cron
+          systemctl start cron
         else
           service cron enable
-          service cron restart
+          service cron start
         fi
         ;;
       esac
@@ -1057,7 +1057,7 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
           echo "Unbound: true" >>${UNBOUND_MANAGER}
           # restart unbound
           if pgrep systemd-journal; then
-            systemctl enable unbound
+            systemctl reenable unbound
             systemctl restart unbound
           else
             service unbound enable
@@ -1149,14 +1149,14 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${CLIENT_NAME}"-${WIRE
       # Service Restart
       if pgrep systemd-journal; then
         systemctl enable wg-quick@${WIREGUARD_PUB_NIC}
-        systemctl restart wg-quick@${WIREGUARD_PUB_NIC}
+        systemctl start wg-quick@${WIREGUARD_PUB_NIC}
         systemctl enable ntp
-        systemctl restart ntp
+        systemctl start ntp
       else
         service wg-quick@${WIREGUARD_PUB_NIC} enable
-        service wg-quick@${WIREGUARD_PUB_NIC} restart
+        service wg-quick@${WIREGUARD_PUB_NIC} start
         service ntp enable
-        service ntp restart
+        service ntp start
       fi
       ntpq -p
       # Generate QR Code
@@ -1221,9 +1221,9 @@ else
       4) # Restart WireGuard
         if [ -x "$(command -v wg)" ]; then
           if pgrep systemd-journal; then
-            systemctl restart wg-quick@${WIREGUARD_PUB_NIC}
+            systemctl start wg-quick@${WIREGUARD_PUB_NIC}
           else
-            service wg-quick@${WIREGUARD_PUB_NIC} restart
+            service wg-quick@${WIREGUARD_PUB_NIC} start
           fi
         fi
         ;;
@@ -1312,12 +1312,14 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
         if { [ "${DISTRO}" == "ubuntu" ] || [ "${DISTRO}" == "debian" ] || [ "${DISTRO}" == "raspbian" ] || [ "${DISTRO}" == "pop" ] || [ "${DISTRO}" == "kali" ] || [ "${DISTRO}" == "linuxmint" ]; }; then
           dpkg-reconfigure wireguard-dkms
           modprobe wireguard
+          systemctl reenable wg-quick@${WIREGUARD_PUB_NIC}
           systemctl restart wg-quick@${WIREGUARD_PUB_NIC}
         elif { [ "${DISTRO}" == "fedora" ] || [ "${DISTRO}" == "centos" ] || [ "${DISTRO}" == "rhel" ]; }; then
           yum reinstall wireguard-tools -y
           service wg-quick@${WIREGUARD_PUB_NIC} restart
         elif { [ "${DISTRO}" == "arch" ] || [ "${DISTRO}" == "archarm" ] || [ "${DISTRO}" == "manjaro" ]; }; then
           pacman -S --noconfirm wireguard-tools
+          systemctl reenable wg-quick@${WIREGUARD_PUB_NIC}
           systemctl restart wg-quick@${WIREGUARD_PUB_NIC}
         elif [ "${DISTRO}" == "alpine" ]; then
           apk fix wireguard-tools
@@ -1365,7 +1367,7 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
             elif [ "${DISTRO}" == "ubuntu" ]; then
               apt-get remove --purge wireguard qrencode haveged -y
               if pgrep systemd-journal; then
-                systemctl enable systemd-resolved
+                systemctl reenable systemd-resolved
                 systemctl restart systemd-resolved
               else
                 service systemd-resolved enable
@@ -1515,8 +1517,10 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
           fi
           # Restart WireGuard
           if pgrep systemd-journal; then
+            systemctl reenable wg-quick@${WIREGUARD_PUB_NIC}
             systemctl restart wg-quick@${WIREGUARD_PUB_NIC}
           else
+            service wg-quick@${WIREGUARD_PUB_NIC} enable
             service wg-quick@${WIREGUARD_PUB_NIC} restart
           fi
         fi

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -854,7 +854,6 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
           apt-get update
           apt-get install raspberrypi-kernel-headers -y
         elif { [ "${DISTRO}" == "arch" ] || [ "${DISTRO}" == "archarm" ] || [ "${DISTRO}" == "manjaro" ]; }; then
-          pacman -Syu
           pacman -Syu --noconfirm --needed linux-headers
         elif [ "${DISTRO}" == "fedora" ]; then
           dnf update -y
@@ -911,9 +910,7 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
           apt-get update
           apt-get install wireguard qrencode haveged ifupdown resolvconf -y
         elif { [ "${DISTRO}" == "arch" ] || [ "${DISTRO}" == "archarm" ] || [ "${DISTRO}" == "manjaro" ]; }; then
-          pacman -Syu
-          pacman -Syu --noconfirm --needed haveged qrencode openresolv
-          pacman -Syu --noconfirm --needed wireguard-tools
+          pacman -Syu --noconfirm --needed haveged qrencode openresolv wireguard-tools
         elif [ "${DISTRO}" = "fedora" ] && [ "${DISTRO_VERSION}" == "32" ]; then
           dnf update -y
           dnf install qrencode wireguard-tools haveged resolvconf -y


### PR DESCRIPTION
I've found some mistakes on the handling of Arch Linux part so I've fixed them, but I'll explain what I did:

- "grep", "gawk", "coreutils", "systemd", "sed" and "iproute2" packages were remove because they are dependencies required by "base" package, which is mandatory since 10/2019 and installed on every Arch Linux install. [More information](https://archlinux.org/news/base-group-replaced-by-mandatory-base-package-manual-intervention-required/).
- "openssl" package was removed because is required by "coreutils" which is required by "base".
- "iptables" package was removed because is required by "systemd" which is required by "base".
- "curl" package was removed because is required by "pacman" which is required by "base".
- I've replaced "cron" with "cronie" because is the default choice of "pacman" and the package used in the script.
- I've replaced "resolvconf" with "openresolv" because is the required dependency of "wireguard-tools".
- I've replaced the old and deprecated "wireguard" package with the new "wireguard-tools".
- I've fixed "pacman" handling for unattended un/installations by replacing the "-y" option (which is wrongly used here) with "--noconfirm".
- I've fixed "pacman" handling for reinstallations by replacing "-Rs" option (for uninstallation) with "-S" which reinstalls packages if they're installed.
- I did some adjustments for service handling and I added an "stop" line on every "disable" for ensuring WireGuard is fully deactivated. Must be reviewed in deep.
- I've removed some redundant use for "pacman".