### PR TITLE
Changed endpoint for detecting IPv4 to increase compatibility

### DIFF
--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -409,15 +409,18 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
       done
       case ${SERVER_HOST_V4_SETTINGS} in
       1)
-        SERVER_HOST_V4="$(curl -4 -s 'https://icanhazip.com')"
+        SERVER_HOST_V4="$(curl -4 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
         if [ -z "${SERVER_HOST_V4}" ]; then
-          echo "Error: Curl unable to locate your server's public IP address."
+            SERVER_HOST_V4="$(curl -4 -s 'https://checkip.amazonaws.com')"
         fi
         ;;
       2)
         read -rp "Custom IPv4:" SERVER_HOST_V4
         if [ -z "${SERVER_HOST_V4}" ]; then
-          SERVER_HOST_V4="$(curl -4 -s 'https://icanhazip.com')"
+          SERVER_HOST_V4="$(curl -4 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
+        fi
+        if [ -z "${SERVER_HOST_V4}" ]; then
+            SERVER_HOST_V4="$(curl -4 -s 'https://checkip.amazonaws.com')"
         fi
         ;;
       esac
@@ -438,15 +441,18 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
       done
       case ${SERVER_HOST_V6_SETTINGS} in
       1)
-        SERVER_HOST_V6="$(curl -6 -s 'https://icanhazip.com')"
+        SERVER_HOST_V6="$(curl -6 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
         if [ -z "${SERVER_HOST_V6}" ]; then
-          echo "Error: Curl unable to locate your server's public IP address."
+          SERVER_HOST_V6="$(curl -6 -s 'https://checkip.amazonaws.com')"
         fi
         ;;
       2)
         read -rp "Custom IPv6:" SERVER_HOST_V6
         if [ -z "${SERVER_HOST_V6}" ]; then
-          SERVER_HOST_V6="$(curl -6 -s 'https://icanhazip.com')"
+          SERVER_HOST_V6="$(curl -6 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
+        fi
+        if [ -z "${SERVER_HOST_V6}" ]; then
+            SERVER_HOST_V6="$(curl -6 -s 'https://checkip.amazonaws.com')"
         fi
         ;;
       esac
@@ -1642,7 +1648,7 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
         # Change the IP address of your wireguard interface.
         if [ -f "${WIREGUARD_INTERFACE}" ]; then
           OLD_SERVER_HOST=$(head -n1 ${WIREGUARD_CONFIG} | awk '{print $4}' | awk -F: '{print $1}')
-          NEW_SERVER_HOST="$(curl -4 -s 'https://icanhazip.com')"
+          NEW_SERVER_HOST="$(curl -4 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
           if [ -z "${NEW_SERVER_HOST}" ]; then
             echo "Error: While attempting to locate your IP address, an error occurred."
           fi

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1693,4 +1693,3 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
   wireguard-next-questions-interface
 
 fi
-=

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -409,7 +409,7 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
       done
       case ${SERVER_HOST_V4_SETTINGS} in
       1)
-        SERVER_HOST_V4="$(curl -4 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
+        SERVER_HOST_V4="$(curl -4 -s 'https://icanhazip.com')"
         if [ -z "${SERVER_HOST_V4}" ]; then
           echo "Error: Curl unable to locate your server's public IP address."
         fi
@@ -417,7 +417,7 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
       2)
         read -rp "Custom IPv4:" SERVER_HOST_V4
         if [ -z "${SERVER_HOST_V4}" ]; then
-          SERVER_HOST_V4="$(curl -4 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
+          SERVER_HOST_V4="$(curl -4 -s 'https://icanhazip.com')"
         fi
         ;;
       esac
@@ -438,7 +438,7 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
       done
       case ${SERVER_HOST_V6_SETTINGS} in
       1)
-        SERVER_HOST_V6="$(curl -6 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
+        SERVER_HOST_V6="$(curl -6 -s 'https://icanhazip.com')"
         if [ -z "${SERVER_HOST_V6}" ]; then
           echo "Error: Curl unable to locate your server's public IP address."
         fi
@@ -446,7 +446,7 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
       2)
         read -rp "Custom IPv6:" SERVER_HOST_V6
         if [ -z "${SERVER_HOST_V6}" ]; then
-          SERVER_HOST_V6="$(curl -6 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
+          SERVER_HOST_V6="$(curl -6 -s 'https://icanhazip.com')"
         fi
         ;;
       esac
@@ -1642,7 +1642,7 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
         # Change the IP address of your wireguard interface.
         if [ -f "${WIREGUARD_INTERFACE}" ]; then
           OLD_SERVER_HOST=$(head -n1 ${WIREGUARD_CONFIG} | awk '{print $4}' | awk -F: '{print $1}')
-          NEW_SERVER_HOST="$(curl -4 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
+          NEW_SERVER_HOST="$(curl -4 -s 'https://icanhazip.com')"
           if [ -z "${NEW_SERVER_HOST}" ]; then
             echo "Error: While attempting to locate your IP address, an error occurred."
           fi

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -411,7 +411,7 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
       1)
         SERVER_HOST_V4="$(curl -4 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
         if [ -z "${SERVER_HOST_V4}" ]; then
-            SERVER_HOST_V4="$(curl -4 -s 'https://checkip.amazonaws.com')"
+          SERVER_HOST_V4="$(curl -4 -s 'https://checkip.amazonaws.com')"
         fi
         ;;
       2)
@@ -420,7 +420,7 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
           SERVER_HOST_V4="$(curl -4 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
         fi
         if [ -z "${SERVER_HOST_V4}" ]; then
-            SERVER_HOST_V4="$(curl -4 -s 'https://checkip.amazonaws.com')"
+          SERVER_HOST_V4="$(curl -4 -s 'https://checkip.amazonaws.com')"
         fi
         ;;
       esac
@@ -452,7 +452,7 @@ if [ ! -f "${WIREGUARD_CONFIG}" ]; then
           SERVER_HOST_V6="$(curl -6 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
         fi
         if [ -z "${SERVER_HOST_V6}" ]; then
-            SERVER_HOST_V6="$(curl -6 -s 'https://checkip.amazonaws.com')"
+          SERVER_HOST_V6="$(curl -6 -s 'https://checkip.amazonaws.com')"
         fi
         ;;
       esac
@@ -1693,3 +1693,4 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
   wireguard-next-questions-interface
 
 fi
+=

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1650,7 +1650,7 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
           OLD_SERVER_HOST=$(head -n1 ${WIREGUARD_CONFIG} | awk '{print $4}' | awk -F: '{print $1}')
           NEW_SERVER_HOST="$(curl -4 -s 'https://api.ipengine.dev' | jq -r '.network.ip')"
           if [ -z "${NEW_SERVER_HOST}" ]; then
-            echo "Error: While attempting to locate your IP address, an error occurred."
+            NEW_SERVER_HOST="$(curl -4 -s 'https://checkip.amazonaws.com')"
           fi
           sed -i "1s/${OLD_SERVER_HOST}/${NEW_SERVER_HOST}/" ${WIREGUARD_CONFIG}
         fi


### PR DESCRIPTION
`https://api.ipengine.dev` is protected by CloudFlare, so using this script on some sort of VPS (like Hetzner) will probably result in CloudFlare blocking the request.

If this occurs, the script will print something like this:
```
parse error: Invalid numeric literal at line 1, column 10
Error: Curl unable to locate your server's public IP address.
```

Changing it to `https://icanhazip.com` or `https://zx2c4.com/ip` should fix this issue.