### PR TITLE
- Removed restart code due to the use of wg-quick strip after a clien…

### DIFF
--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1184,9 +1184,6 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
           echo "$(date +%M) $(date +%H) $(date +%d) $(date +%m) * echo -e \"${NEW_CLIENT_NAME}\" | ${CURRENT_FILE_PATH} --remove"
         } | crontab -
       fi
-      # A restart of wireguard is not needed due to the use of 'wg-quick strip.' Restarting
-      # will disrupt all existing VPN connections.  The use of 'wg-quick strip' dynamically
-      # adds the new client information without disrupting existing VPN sessions.
       qrencode -t ansiutf8 -r ${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${WIREGUARD_PUB_NIC}.conf
       echo "Client config --> ${WIREGUARD_CLIENT_PATH}/${NEW_CLIENT_NAME}-${WIREGUARD_PUB_NIC}.conf"
       ;;

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1184,14 +1184,9 @@ PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${
           echo "$(date +%M) $(date +%H) $(date +%d) $(date +%m) * echo -e \"${NEW_CLIENT_NAME}\" | ${CURRENT_FILE_PATH} --remove"
         } | crontab -
       fi
-      # Service Restart
-      if pgrep systemd-journal; then
-        systemctl reenable wg-quick@${WIREGUARD_PUB_NIC}
-        systemctl restart wg-quick@${WIREGUARD_PUB_NIC}
-      else
-        service wg-quick@${WIREGUARD_PUB_NIC} enable
-        service wg-quick@${WIREGUARD_PUB_NIC} restart
-      fi
+      # A restart of wireguard is not needed due to the use of 'wg-quick strip.' Restarting
+      # will disrupt all existing VPN connections.  The use of 'wg-quick strip' dynamically
+      # adds the new client information without disrupting existing VPN sessions.
       qrencode -t ansiutf8 -r ${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${WIREGUARD_PUB_NIC}.conf
       echo "Client config --> ${WIREGUARD_CLIENT_PATH}/${NEW_CLIENT_NAME}-${WIREGUARD_PUB_NIC}.conf"
       ;;


### PR DESCRIPTION
I suggest removing the restart commands after a user is added because it will disrupt existing VPN connections.  This is similar to Pull Request #139  where a restart of wireguard is not required after removal due to the use of 'wg-quick strip.'