### PR TITLE
Fix for kernel version check - tested

### DIFF
--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -78,11 +78,13 @@ function kernel-check() {
   ALLOWED_KERNEL_VERSION="3.1"
   ALLOWED_KERNEL_VERSION_MAJOR=$(echo ${ALLOWED_KERNEL_VERSION} | cut -d'.' -f1)
   ALLOWED_KERNEL_VERSION_MINOR=$(echo ${ALLOWED_KERNEL_VERSION} | cut -d'.' -f2)
-  if (($(echo "${CURRENT_KERNEL_VERSION_MAJOR} < ${ALLOWED_KERNEL_VERSION_MAJOR}" | bc -l))); then
-    echo "Error: Kernel ${CURRENT_KERNEL_VERSION_MAJOR}.${CURRENT_KERNEL_VERSION_MINOR} not supported, please update to ${ALLOWED_KERNEL_VERSION} or higher."
+  if [ "${CURRENT_KERNEL_MAJOR_VERSION_}" -lt "${ALLOWED_KERNEL_MAJOR_VERSION}" ]; then
+    echo "Error: Kernel ${CURRENT_KERNEL_VERSION} not supported, please update to ${ALLOWED_KERNEL_VERSION}."
     exit
-    if (($(echo "${CURRENT_KERNEL_VERSION_MINOR} < ${ALLOWED_KERNEL_VERSION_MINOR}" | bc -l))); then
-      echo "Error: Kernel ${CURRENT_KERNEL_VERSION_MAJOR}.${CURRENT_KERNEL_VERSION_MINOR} not supported, please update to ${ALLOWED_KERNEL_VERSION} or higher."
+  fi
+  if [ "${CURRENT_KERNEL_MAJOR_VERSION_}" == "${ALLOWED_KERNEL_MAJOR_VERSION}" ]; then
+    if [ "${CURRENT_KERNEL_MINOR_VERSION}" -lt "${ALLOWED_KERNEL_MINOR_VERSION}" ]; then
+      echo "Error: Kernel ${CURRENT_KERNEL_VERSION} not supported, please update to ${ALLOWED_KERNEL_VERSION}."
       exit
     fi
   fi

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -73,10 +73,18 @@ virt-check
 # Lets check the kernel version
 function kernel-check() {
   CURRENT_KERNEL_VERSION=$(uname -r | cut -d'.' -f1-2)
+  CURRENT_KERNEL_VERSION_MAJOR=$(uname -r | cut -d'.' -f1)
+  CURRENT_KERNEL_VERSION_MINOR=$(uname -r | cut -d'.' -f2)
   ALLOWED_KERNEL_VERSION="3.1"
-  if (($(echo "${CURRENT_KERNEL_VERSION} <= ${ALLOWED_KERNEL_VERSION}" | bc -l))); then
-    echo "Error: Kernel ${CURRENT_KERNEL_VERSION} not supported, please update to ${ALLOWED_KERNEL_VERSION}."
+  ALLOWED_KERNEL_VERSION_MAJOR="3"
+  ALLOWED_KERNEL_VERSION_MINOR="1"
+  if (($(echo "${CURRENT_KERNEL_VERSION_MAJOR} < ${ALLOWED_KERNEL_VERSION_MAJOR}" | bc -l))); then
+    echo "Error: Kernel ${CURRENT_KERNEL_VERSION_MAJOR}.${CURRENT_KERNEL_VERSION_MINOR} not supported, please update to ${ALLOWED_KERNEL_VERSION} or higher."
     exit
+    if (($(echo "${CURRENT_KERNEL_VERSION_MINOR} < ${ALLOWED_KERNEL_VERSION_MINOR}" | bc -l))); then
+      echo "Error: Kernel ${CURRENT_KERNEL_VERSION_MAJOR}.${CURRENT_KERNEL_VERSION_MINOR} not supported, please update to ${ALLOWED_KERNEL_VERSION} or higher."
+      exit
+    fi
   fi
 }
 

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -73,11 +73,11 @@ virt-check
 # Lets check the kernel version
 function kernel-check() {
   CURRENT_KERNEL_VERSION=$(uname -r | cut -d'.' -f1-2)
-  CURRENT_KERNEL_VERSION_MAJOR=$(uname -r | cut -d'.' -f1)
-  CURRENT_KERNEL_VERSION_MINOR=$(uname -r | cut -d'.' -f2)
+  CURRENT_KERNEL_VERSION_MAJOR=$(echo ${CURRENT_KERNEL_VERSION} | cut -d'.' -f1)
+  CURRENT_KERNEL_VERSION_MINOR=$(echo ${CURRENT_KERNEL_VERSION} | cut -d'.' -f2)
   ALLOWED_KERNEL_VERSION="3.1"
-  ALLOWED_KERNEL_VERSION_MAJOR="3"
-  ALLOWED_KERNEL_VERSION_MINOR="1"
+  ALLOWED_KERNEL_VERSION_MAJOR=$(echo ${ALLOWED_KERNEL_VERSION} | cut -d'.' -f1)
+  ALLOWED_KERNEL_VERSION_MINOR=$(echo ${ALLOWED_KERNEL_VERSION} | cut -d'.' -f2)
   if (($(echo "${CURRENT_KERNEL_VERSION_MAJOR} < ${ALLOWED_KERNEL_VERSION_MAJOR}" | bc -l))); then
     echo "Error: Kernel ${CURRENT_KERNEL_VERSION_MAJOR}.${CURRENT_KERNEL_VERSION_MINOR} not supported, please update to ${ALLOWED_KERNEL_VERSION} or higher."
     exit

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -73,16 +73,16 @@ virt-check
 # Lets check the kernel version
 function kernel-check() {
   CURRENT_KERNEL_VERSION=$(uname -r | cut -d'.' -f1-2)
-  CURRENT_KERNEL_MAJOR_VERSION_=$(echo ${CURRENT_KERNEL_VERSION} | cut -d'.' -f1)
+  CURRENT_KERNEL_MAJOR_VERSION=$(echo ${CURRENT_KERNEL_VERSION} | cut -d'.' -f1)
   CURRENT_KERNEL_MINOR_VERSION=$(echo ${CURRENT_KERNEL_VERSION} | cut -d'.' -f2)
   ALLOWED_KERNEL_VERSION="3.1"
   ALLOWED_KERNEL_MAJOR_VERSION=$(echo ${ALLOWED_KERNEL_VERSION} | cut -d'.' -f1)
   ALLOWED_KERNEL_MINOR_VERSION=$(echo ${ALLOWED_KERNEL_VERSION} | cut -d'.' -f2)
-  if [ "${CURRENT_KERNEL_MAJOR_VERSION_}" -lt "${ALLOWED_KERNEL_MAJOR_VERSION}" ]; then
+  if [ "${CURRENT_KERNEL_MAJOR_VERSION}" -lt "${ALLOWED_KERNEL_MAJOR_VERSION}" ]; then
     echo "Error: Kernel ${CURRENT_KERNEL_VERSION} not supported, please update to ${ALLOWED_KERNEL_VERSION}."
     exit
   fi
-  if [ "${CURRENT_KERNEL_MAJOR_VERSION_}" == "${ALLOWED_KERNEL_MAJOR_VERSION}" ]; then
+  if [ "${CURRENT_KERNEL_MAJOR_VERSION}" == "${ALLOWED_KERNEL_MAJOR_VERSION}" ]; then
     if [ "${CURRENT_KERNEL_MINOR_VERSION}" -lt "${ALLOWED_KERNEL_MINOR_VERSION}" ]; then
       echo "Error: Kernel ${CURRENT_KERNEL_VERSION} not supported, please update to ${ALLOWED_KERNEL_VERSION}."
       exit

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -73,11 +73,11 @@ virt-check
 # Lets check the kernel version
 function kernel-check() {
   CURRENT_KERNEL_VERSION=$(uname -r | cut -d'.' -f1-2)
-  CURRENT_KERNEL_VERSION_MAJOR=$(echo ${CURRENT_KERNEL_VERSION} | cut -d'.' -f1)
-  CURRENT_KERNEL_VERSION_MINOR=$(echo ${CURRENT_KERNEL_VERSION} | cut -d'.' -f2)
+  CURRENT_KERNEL_MAJOR_VERSION_=$(echo ${CURRENT_KERNEL_VERSION} | cut -d'.' -f1)
+  CURRENT_KERNEL_MINOR_VERSION=$(echo ${CURRENT_KERNEL_VERSION} | cut -d'.' -f2)
   ALLOWED_KERNEL_VERSION="3.1"
-  ALLOWED_KERNEL_VERSION_MAJOR=$(echo ${ALLOWED_KERNEL_VERSION} | cut -d'.' -f1)
-  ALLOWED_KERNEL_VERSION_MINOR=$(echo ${ALLOWED_KERNEL_VERSION} | cut -d'.' -f2)
+  ALLOWED_KERNEL_MAJOR_VERSION=$(echo ${ALLOWED_KERNEL_VERSION} | cut -d'.' -f1)
+  ALLOWED_KERNEL_MINOR_VERSION=$(echo ${ALLOWED_KERNEL_VERSION} | cut -d'.' -f2)
   if [ "${CURRENT_KERNEL_MAJOR_VERSION_}" -lt "${ALLOWED_KERNEL_MAJOR_VERSION}" ]; then
     echo "Error: Kernel ${CURRENT_KERNEL_VERSION} not supported, please update to ${ALLOWED_KERNEL_VERSION}."
     exit


### PR DESCRIPTION
Test case 1:
```
function kernel-check() {
  CURRENT_KERNEL_VERSION="3.10"
  CURRENT_KERNEL_VERSION_MAJOR="3"
  CURRENT_KERNEL_VERSION_MINOR="10"
  ALLOWED_KERNEL_VERSION="3.1"
  ALLOWED_KERNEL_VERSION_MAJOR="3"
  ALLOWED_KERNEL_VERSION_MINOR="1"
  if (($(echo "${CURRENT_KERNEL_VERSION_MAJOR} < ${ALLOWED_KERNEL_VERSION_MAJOR}" | bc -l))); then
    echo "Error: Kernel ${CURRENT_KERNEL_VERSION_MAJOR}.${CURRENT_KERNEL_VERSION_MINOR} not supported, please update to ${ALLOWED_KERNEL_VERSION} or higher."
    exit
    if (($(echo "${CURRENT_KERNEL_VERSION_MINOR} < ${ALLOWED_KERNEL_VERSION_MINOR}" | bc -l))); then
      echo "Error: Kernel ${CURRENT_KERNEL_VERSION_MAJOR}.${CURRENT_KERNEL_VERSION_MINOR} not supported, please update to ${ALLOWED_KERNEL_VERSION} or higher."
      exit
    fi
  fi
echo "Kernel ${CURRENT_KERNEL_VERSION_MAJOR}.${CURRENT_KERNEL_VERSION_MINOR} is higher than or equal to ${ALLOWED_KERNEL_VERSION_MAJOR}.${ALLOWED_KERNEL_VERSION_MINOR} and is supported"
}
```
Test case 2:
```
function kernel-check() {
  CURRENT_KERNEL_VERSION="4.18"
  CURRENT_KERNEL_VERSION_MAJOR="4"
  CURRENT_KERNEL_VERSION_MINOR="18"
  ALLOWED_KERNEL_VERSION="3.19"
  ALLOWED_KERNEL_VERSION_MAJOR="3"
  ALLOWED_KERNEL_VERSION_MINOR="19"
  if (($(echo "${CURRENT_KERNEL_VERSION_MAJOR} < ${ALLOWED_KERNEL_VERSION_MAJOR}" | bc -l))); then
    echo "Error: Kernel ${CURRENT_KERNEL_VERSION_MAJOR}.${CURRENT_KERNEL_VERSION_MINOR} not supported, please update to ${ALLOWED_KERNEL_VERSION} or higher."
    exit
    if (($(echo "${CURRENT_KERNEL_VERSION_MINOR} < ${ALLOWED_KERNEL_VERSION_MINOR}" | bc -l))); then
      echo "Error: Kernel ${CURRENT_KERNEL_VERSION_MAJOR}.${CURRENT_KERNEL_VERSION_MINOR} not supported, please update to ${ALLOWED_KERNEL_VERSION} or higher."
      exit
    fi
  fi
echo "Kernel ${CURRENT_KERNEL_VERSION_MAJOR}.${CURRENT_KERNEL_VERSION_MINOR} is higher than or equal to ${ALLOWED_KERNEL_VERSION_MAJOR}.${ALLOWED_KERNEL_VERSION_MINOR} and is supported"
}
```