### PR TITLE
Only support certain init systems.

### DIFF
--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -114,7 +114,7 @@ function check-current-init-system() {
   esac
 }
 
-# Check if the current init system is supported.
+# Check if the current init system is supported
 check-current-init-system
 
 # Global variables

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -102,9 +102,22 @@ function kernel-check() {
 
 kernel-check
 
+# Check the current init system.
+function check-current-init-system() {
+  CURRENT_INIT_SYSTEM=$(ps --no-headers -o comm 1)
+  case ${CURRENT_INIT_SYSTEM} in
+  *"systemd"* | *"init"*) ;;
+  *)
+    echo "${CURRENT_INIT_SYSTEM} init is not supported (yet)."
+    exit
+    ;;
+  esac
+}
+
+check-current-init-system
+
 # Global variables
 CURRENT_FILE_PATH=$(realpath "${0}")
-CURRENT_INIT_SYSTEM=$(ps --no-headers -o comm 1)
 WIREGUARD_WEBSITE_URL="https://www.wireguard.com"
 WIREGUARD_PATH="/etc/wireguard"
 WIREGUARD_CLIENT_PATH="${WIREGUARD_PATH}/clients"

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -114,6 +114,7 @@ function check-current-init-system() {
   esac
 }
 
+# Check if the current init system is supported.
 check-current-init-system
 
 # Global variables

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -62,7 +62,7 @@ function installing-system-requirements() {
   fi
 }
 
-# check for requirements
+# check for requirements.
 installing-system-requirements
 
 # Checking For Virtualization


### PR DESCRIPTION
- Added an extra check to make sure we currently support the init system.
```
ps --no-headers -o comm 1
ps | sed -n 2p | tr -s " " | cut -d " " -f5
```