### PR TITLE
Fix FREE_SPACE_ON_DRIVE_IN_MB variable name in wireguard-manager.sh

### DIFF
--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -120,7 +120,7 @@ check-current-init-system
 # Check if there are enough space to continue with the installation.
 function check-disk-space() {
   FREE_SPACE_ON_DRIVE_IN_MB=$(df -m / | tr --squeeze-repeats " " | tail -n1 | cut --delimiter=" " --fields=4)
-  if [ "${FREE_SPACE_ON_DRIVE}" -le 1024 ]; then
+  if [ "${FREE_SPACE_ON_DRIVE_IN_MB}" -le 1024 ]; then
     echo "Error: More than 1 GB of free space is needed to install everything."
     exit
   fi


### PR DESCRIPTION
Signed-off-by: Ben Stoutenburgh <maristgeek@gmail.com>

Should address this message:
```
./wireguard-manager.sh: line 123: [: : integer expression expected
```