### PR TITLE
fix: bug with duplicated port for additional client configurations

### DIFF
--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1624,7 +1624,7 @@ MTU = ${MTU_CHOICE}
 PrivateKey = ${CLIENT_PRIVKEY}
 [Peer]
 AllowedIPs = ${CLIENT_ALLOWED_IP}
-Endpoint = ${SERVER_HOST} # because we took the value from the WG config file, it contains host:port together.
+Endpoint = ${SERVER_HOST}
 PersistentKeepalive = ${NAT_CHOICE}
 PresharedKey = ${PRESHARED_KEY}
 PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${WIREGUARD_PUB_NIC}.conf

--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -1624,7 +1624,7 @@ MTU = ${MTU_CHOICE}
 PrivateKey = ${CLIENT_PRIVKEY}
 [Peer]
 AllowedIPs = ${CLIENT_ALLOWED_IP}
-Endpoint = ${SERVER_HOST}${SERVER_PORT}
+Endpoint = ${SERVER_HOST} # because we took the value from the WG config file, it contains host:port together.
 PersistentKeepalive = ${NAT_CHOICE}
 PresharedKey = ${PRESHARED_KEY}
 PublicKey = ${SERVER_PUBKEY}" >>${WIREGUARD_CLIENT_PATH}/"${NEW_CLIENT_NAME}"-${WIREGUARD_PUB_NIC}.conf


### PR DESCRIPTION
This change fixes the bug that occurred when you tried to create additional client (peer) configs and got the Endpoint value in the form of "host:portport" instead of "host:port"

Related issue: #439 